### PR TITLE
Fix project references to use shared library path

### DIFF
--- a/samples/LabelPrint/C#/LabelPrint.csproj
+++ b/samples/LabelPrint/C#/LabelPrint.csproj
@@ -29,10 +29,9 @@
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Seagull.BarTender.Print, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86">
+  <ItemGroup>    <Reference Include="Seagull.BarTender.Print, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Seagull.BarTender\bin\Release\Seagull.BarTender.Print.dll</HintPath>
+      <HintPath>..\..\..\lib\References\Seagull.BarTender.Print.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/samples/LabelPrint/VB/LabelPrint.vbproj
+++ b/samples/LabelPrint/VB/LabelPrint.vbproj
@@ -37,10 +37,9 @@
     <PlatformTarget>x86</PlatformTarget>
     <NoWarn>42353,42354,42355</NoWarn>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Seagull.BarTender.Print, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86">
+  <ItemGroup>     <Reference Include="Seagull.BarTender.Print, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Seagull.BarTender\bin\Release\Seagull.BarTender.Print.dll</HintPath>
+      <HintPath>..\..\..\lib\References\Seagull.BarTender.Print.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/samples/PrintJobStatusMonitor/C#/PrintJobStatusMonitor.csproj
+++ b/samples/PrintJobStatusMonitor/C#/PrintJobStatusMonitor.csproj
@@ -29,10 +29,9 @@
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Seagull.BarTender.Print, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86">
+  <ItemGroup>    <Reference Include="Seagull.BarTender.Print, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
-       <HintPath>..\..\..\Seagull.BarTender\bin\Release\Seagull.BarTender.Print.dll</HintPath>
+      <HintPath>..\..\..\lib\References\Seagull.BarTender.Print.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/samples/PrintJobStatusMonitor/VB/PrintJobStatusMonitor.vbproj
+++ b/samples/PrintJobStatusMonitor/VB/PrintJobStatusMonitor.vbproj
@@ -28,11 +28,10 @@
 		<ErrorReport>prompt</ErrorReport>
 		<PlatformTarget>x86</PlatformTarget>
 	</PropertyGroup>
-	<ItemGroup>
-		<Reference Include="Seagull.BarTender.Print, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86">
-			<SpecificVersion>False</SpecificVersion>
-         <HintPath>..\..\..\Seagull.BarTender\bin\Release\Seagull.BarTender.Print.dll</HintPath>
-		</Reference>
+	<ItemGroup>        <Reference Include="Seagull.BarTender.Print, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86">
+          <SpecificVersion>False</SpecificVersion>
+          <HintPath>..\..\..\lib\References\Seagull.BarTender.Print.dll</HintPath>
+        </Reference>
 		<Reference Include="System"/>
 		<Reference Include="System.Data"/>
 		<Reference Include="System.Deployment"/>

--- a/samples/PrintPreview/C#/PrintPreview.csproj
+++ b/samples/PrintPreview/C#/PrintPreview.csproj
@@ -29,10 +29,9 @@
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Seagull.BarTender.Print, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86">
+  <ItemGroup>    <Reference Include="Seagull.BarTender.Print, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
-       <HintPath>..\..\..\Seagull.BarTender\bin\Release\Seagull.BarTender.Print.dll</HintPath>
+      <HintPath>..\..\..\lib\References\Seagull.BarTender.Print.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/samples/PrintPreview/VB/PrintPreview.vbproj
+++ b/samples/PrintPreview/VB/PrintPreview.vbproj
@@ -28,11 +28,10 @@
 		<ErrorReport>prompt</ErrorReport>
 		<PlatformTarget>x86</PlatformTarget>
 	</PropertyGroup>
-	<ItemGroup>
-		<Reference Include="Seagull.BarTender.Print, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86">
-			<SpecificVersion>False</SpecificVersion>
-         <HintPath>..\..\..\Seagull.BarTender\bin\Release\Seagull.BarTender.Print.dll</HintPath>
-		</Reference>
+	<ItemGroup>        <Reference Include="Seagull.BarTender.Print, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86">
+          <SpecificVersion>False</SpecificVersion>
+          <HintPath>..\..\..\lib\References\Seagull.BarTender.Print.dll</HintPath>
+        </Reference>
 		<Reference Include="System"/>
 		<Reference Include="System.Data"/>
 		<Reference Include="System.Deployment"/>

--- a/samples/PrintToFileManager/C#/PrintToFileManager.csproj
+++ b/samples/PrintToFileManager/C#/PrintToFileManager.csproj
@@ -29,10 +29,9 @@
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Seagull.BarTender.Print, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86">
+  <ItemGroup>    <Reference Include="Seagull.BarTender.Print, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
-       <HintPath>..\..\..\Seagull.BarTender\bin\Release\Seagull.BarTender.Print.dll</HintPath>
+      <HintPath>..\..\..\lib\References\Seagull.BarTender.Print.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/samples/PrintToFileManager/VB/PrintToFileManager.vbproj
+++ b/samples/PrintToFileManager/VB/PrintToFileManager.vbproj
@@ -28,11 +28,10 @@
 		<ErrorReport>prompt</ErrorReport>
 		<PlatformTarget>x86</PlatformTarget>
 	</PropertyGroup>
-	<ItemGroup>
-		<Reference Include="Seagull.BarTender.Print, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86">
-			<SpecificVersion>False</SpecificVersion>
-         <HintPath>..\..\..\Seagull.BarTender\bin\Release\Seagull.BarTender.Print.dll</HintPath>
-		</Reference>
+	<ItemGroup>        <Reference Include="Seagull.BarTender.Print, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86">
+          <SpecificVersion>False</SpecificVersion>
+          <HintPath>..\..\..\lib\References\Seagull.BarTender.Print.dll</HintPath>
+        </Reference>
 		<Reference Include="System"/>
 		<Reference Include="System.Data"/>
 		<Reference Include="System.Deployment"/>

--- a/samples/XMLScripter/C#/XMLScripter.csproj
+++ b/samples/XMLScripter/C#/XMLScripter.csproj
@@ -29,10 +29,9 @@
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Seagull.BarTender.Print, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86">
+  <ItemGroup>    <Reference Include="Seagull.BarTender.Print, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
-       <HintPath>..\..\..\Seagull.BarTender\bin\Release\Seagull.BarTender.Print.dll</HintPath>
+      <HintPath>..\..\..\lib\References\Seagull.BarTender.Print.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/samples/XMLScripter/VB/XMLScripter.vbproj
+++ b/samples/XMLScripter/VB/XMLScripter.vbproj
@@ -29,11 +29,10 @@
     <ErrorReport>prompt</ErrorReport>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Seagull.BarTender.Print, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86">
-      <SpecificVersion>False</SpecificVersion>
-       <HintPath>..\..\..\Seagull.BarTender\bin\Release\Seagull.BarTender.Print.dll</HintPath>
-    </Reference>
+  <ItemGroup>      <Reference Include="Seagull.BarTender.Print, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86">
+        <SpecificVersion>False</SpecificVersion>
+        <HintPath>..\..\..\lib\References\Seagull.BarTender.Print.dll</HintPath>
+      </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Deployment" />

--- a/server-samples/TaskMaster/C#/TaskMaster.csproj
+++ b/server-samples/TaskMaster/C#/TaskMaster.csproj
@@ -30,10 +30,9 @@
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Interop.BarTender, Version=10.1.3.1, Culture=neutral, PublicKeyToken=109ff779a1b4cbc7, processorArchitecture=MSIL" />
-    <Reference Include="Seagull.BarTender.Print, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86">
+    <Reference Include="Interop.BarTender, Version=10.1.3.1, Culture=neutral, PublicKeyToken=109ff779a1b4cbc7, processorArchitecture=MSIL" />    <Reference Include="Seagull.BarTender.Print, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\Assemblies\Seagull.BarTender.Print.dll</HintPath>
+      <HintPath>..\..\..\lib\References\Seagull.BarTender.Print.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/server-samples/TaskMaster/VB/TaskMaster.vbproj
+++ b/server-samples/TaskMaster/VB/TaskMaster.vbproj
@@ -30,10 +30,9 @@
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Interop.BarTender, Version=10.1.3.1, Culture=neutral, PublicKeyToken=109ff779a1b4cbc7, processorArchitecture=MSIL" />
-    <Reference Include="Seagull.BarTender.Print, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86">
+    <Reference Include="Interop.BarTender, Version=10.1.3.1, Culture=neutral, PublicKeyToken=109ff779a1b4cbc7, processorArchitecture=MSIL" />     <Reference Include="Seagull.BarTender.Print, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Seagull.BarTender\bin\Release\Seagull.BarTender.Print.dll</HintPath>
+      <HintPath>..\..\..\lib\References\Seagull.BarTender.Print.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />


### PR DESCRIPTION
- Standardized reference paths across all samples
- Ensures consistent library versions across all samples
- Simplifies project maintenance and updates